### PR TITLE
fix: escapar variables Docker en template literals de las slides

### DIFF
--- a/docs/slides/infraestructura/targets.js
+++ b/docs/slides/infraestructura/targets.js
@@ -125,9 +125,9 @@ export default {
     <span class="c-yellow">mem_reservation</span>:<span class="c-green"> 128m</span>
     <span class="c-yellow">environment</span>:
       - <span class="c-green">DB_SERVER=db</span>
-      - <span class="c-green">DB_DATABASE=${DVWA_DB:-dvwa}</span>
-      - <span class="c-green">DB_USER=${DVWA_USER:-dvwa}</span>
-      - <span class="c-green">DB_PASSWORD=${DVWA_PASSWORD:-p@ssw0rd}</span>
+      - <span class="c-green">DB_DATABASE=\${DVWA_DB:-dvwa}</span>
+      - <span class="c-green">DB_USER=\${DVWA_USER:-dvwa}</span>
+      - <span class="c-green">DB_PASSWORD=\${DVWA_PASSWORD:-p@ssw0rd}</span>
     <span class="c-yellow">depends_on</span>:
       <span class="c-yellow">db</span>:
         <span class="c-yellow">condition</span>:<span class="c-green"> service_healthy</span>
@@ -143,10 +143,10 @@ export default {
     <span class="c-yellow">mem_limit</span>:<span class="c-green"> 256m</span>
     <span class="c-yellow">mem_reservation</span>:<span class="c-green"> 128m</span>
     <span class="c-yellow">environment</span>:
-      - <span class="c-green">MYSQL_ROOT_PASSWORD=${DVWA_ROOT_PASSWORD:-dvwa_root}</span>
-      - <span class="c-green">MYSQL_DATABASE=${DVWA_DB:-dvwa}</span>
-      - <span class="c-green">MYSQL_USER=${DVWA_USER:-dvwa}</span>
-      - <span class="c-green">MYSQL_PASSWORD=${DVWA_PASSWORD:-p@ssw0rd}</span>
+      - <span class="c-green">MYSQL_ROOT_PASSWORD=\${DVWA_ROOT_PASSWORD:-dvwa_root}</span>
+      - <span class="c-green">MYSQL_DATABASE=\${DVWA_DB:-dvwa}</span>
+      - <span class="c-green">MYSQL_USER=\${DVWA_USER:-dvwa}</span>
+      - <span class="c-green">MYSQL_PASSWORD=\${DVWA_PASSWORD:-p@ssw0rd}</span>
     <span class="c-yellow">volumes</span>:
       - <span class="c-green">dvwa-db-data:/var/lib/mysql</span>
     <span class="c-yellow">networks</span>:
@@ -155,7 +155,7 @@ export default {
       <span class="c-yellow">test</span>:
           [
             &quot;CMD-SHELL&quot;,
-            &quot;mysqladmin ping -h localhost -u root -p${DVWA_ROOT_PASSWORD:-dvwa_root} --silent&quot;,
+            &quot;mysqladmin ping -h localhost -u root -p\${DVWA_ROOT_PASSWORD:-dvwa_root} --silent&quot;,
           ]
       <span class="c-yellow">interval</span>:<span class="c-green"> 10s</span>
       <span class="c-yellow">timeout</span>:<span class="c-green"> 5s</span>
@@ -248,6 +248,80 @@ export default {
         <strong>Credenciales DVWA:</strong> usuario <code>admin</code> · contraseña <code>password</code><br>
         Establecer nivel <strong>Low</strong> en DVWA Security para maximizar la superficie de ataque durante el escaneo.
       </div>
+
+      <textarea id="targets-compose-yml" hidden>services:
+  # ─── JUICE SHOP ───────────────────────────────────────────────
+  juice-shop:
+    image: bkimminich/juice-shop
+    container_name: juice-shop
+    restart: unless-stopped
+    mem_limit: 512m
+    mem_reservation: 256m
+    ports:
+      - "3000:3000"
+    networks:
+      - dmz-internal
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─── DVWA ─────────────────────────────────────────────────────
+  dvwa:
+    image: ghcr.io/digininja/dvwa:latest
+    container_name: dvwa
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    environment:
+      - DB_SERVER=db
+      - DB_DATABASE=\${DVWA_DB:-dvwa}
+      - DB_USER=\${DVWA_USER:-dvwa}
+      - DB_PASSWORD=\${DVWA_PASSWORD:-p@ssw0rd}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    networks:
+      - dmz-internal
+
+  # ─── MARIADB ──────────────────────────────────────────────────
+  db:
+    image: mariadb:10.11
+    container_name: dvwa-db
+    restart: unless-stopped
+    mem_limit: 256m
+    mem_reservation: 128m
+    environment:
+      - MYSQL_ROOT_PASSWORD=\${DVWA_ROOT_PASSWORD:-dvwa_root}
+      - MYSQL_DATABASE=\${DVWA_DB:-dvwa}
+      - MYSQL_USER=\${DVWA_USER:-dvwa}
+      - MYSQL_PASSWORD=\${DVWA_PASSWORD:-p@ssw0rd}
+    volumes:
+      - dvwa-db-data:/var/lib/mysql
+    networks:
+      - dmz-internal
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -u root -p\${DVWA_ROOT_PASSWORD:-dvwa_root} --silent",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
+
+# ─── VOLÚMENES ────────────────────────────────────────────────
+volumes:
+  dvwa-db-data:
+
+networks:
+  dmz-internal:
+    driver: bridge</textarea>
     </div>
   `,
 };

--- a/docs/slides/secops/lab.js
+++ b/docs/slides/secops/lab.js
@@ -142,15 +142,15 @@ export default {
         zap.sh -daemon -host 0.0.0.0 -port 8090
         -config api.addrs.addr.name=.*
         -config api.addrs.addr.regex=true
-        -config api.key=${ZAP_API_KEY}
+        -config api.key=\${ZAP_API_KEY}
         -config api.disablekey=false
         -config connection.timeoutInSecs=300
     <span class="c-yellow">ports</span>:
       - <span class="c-green">&quot;8090:8090&quot;</span>
     <span class="c-yellow">environment</span>:
-      - <span class="c-green">ZAP_API_KEY=${ZAP_API_KEY}</span>
-      - <span class="c-green">DMZ_DVWA=${DMZ_DVWA}</span>
-      - <span class="c-green">DMZ_JUICESHOP=${DMZ_JUICESHOP}</span>
+      - <span class="c-green">ZAP_API_KEY=\${ZAP_API_KEY}</span>
+      - <span class="c-green">DMZ_DVWA=\${DMZ_DVWA}</span>
+      - <span class="c-green">DMZ_JUICESHOP=\${DMZ_JUICESHOP}</span>
       - <span class="c-green">_JAVA_OPTIONS=-Xmx2g</span>
     <span class="c-yellow">volumes</span>:
       - <span class="c-green">zap-data:/zap/wrk</span>
@@ -174,8 +174,8 @@ export default {
     <span class="c-yellow">restart</span>:<span class="c-green"> unless-stopped</span>
     <span class="c-yellow">entrypoint</span>:<span class="c-green"> [&quot;sleep&quot;, &quot;infinity&quot;]</span>
     <span class="c-yellow">environment</span>:
-      - <span class="c-green">DMZ_DVWA=${DMZ_DVWA}</span>
-      - <span class="c-green">DMZ_JUICESHOP=${DMZ_JUICESHOP}</span>
+      - <span class="c-green">DMZ_DVWA=\${DMZ_DVWA}</span>
+      - <span class="c-green">DMZ_JUICESHOP=\${DMZ_JUICESHOP}</span>
     <span class="c-yellow">volumes</span>:
       - <span class="c-green">nuclei-templates:/root/nuclei-templates</span>
       - <span class="c-green">nuclei-reports:/reports</span>
@@ -222,8 +222,8 @@ export default {
     <span class="c-yellow">ports</span>:
       - <span class="c-green">&quot;5000:5000&quot;</span>
     <span class="c-yellow">environment</span>:
-      - <span class="c-green">DMZ_DVWA=${DMZ_DVWA}</span>
-      - <span class="c-green">DMZ_JUICESHOP=${DMZ_JUICESHOP}</span>
+      - <span class="c-green">DMZ_DVWA=\${DMZ_DVWA}</span>
+      - <span class="c-green">DMZ_JUICESHOP=\${DMZ_JUICESHOP}</span>
     <span class="c-yellow">volumes</span>:
       - <span class="c-green">nuclei-templates:/root/nuclei-templates</span>
       - <span class="c-green">nuclei-reports:/reports</span>
@@ -246,22 +246,22 @@ export default {
       - <span class="c-green">N8N_HOST=0.0.0.0</span>
       - <span class="c-green">N8N_PORT=5678</span>
       - <span class="c-green">N8N_PROTOCOL=http</span>
-      - <span class="c-green">WEBHOOK_URL=http://${SECOPS_IP}:5678</span>
+      - <span class="c-green">WEBHOOK_URL=http://\${SECOPS_IP}:5678</span>
       - <span class="c-green">N8N_BASIC_AUTH_ACTIVE=false</span>
-      - <span class="c-green">N8N_USER_MANAGEMENT_JWT_SECRET=${N8N_JWT_SECRET}</span>
-      - <span class="c-green">N8N_DEFAULT_USER_EMAIL=${N8N_USER}</span>
-      - <span class="c-green">N8N_DEFAULT_USER_PASSWORD=${N8N_PASSWORD}</span>
+      - <span class="c-green">N8N_USER_MANAGEMENT_JWT_SECRET=\${N8N_JWT_SECRET}</span>
+      - <span class="c-green">N8N_DEFAULT_USER_EMAIL=\${N8N_USER}</span>
+      - <span class="c-green">N8N_DEFAULT_USER_PASSWORD=\${N8N_PASSWORD}</span>
       - <span class="c-green">N8N_LOG_LEVEL=info</span>
       - <span class="c-green">N8N_COMMUNITY_PACKAGES_ENABLED=true</span>
       - <span class="c-green">N8N_SECURE_COOKIE=false</span>
       - <span class="c-green">N8N_ALLOW_EXEC=true</span>
       - <span class="c-green">GENERIC_TIMEZONE=Europe/Madrid</span>
       - <span class="c-green">TZ=Europe/Madrid</span>
-      - <span class="c-green">ZAP_API_KEY=${ZAP_API_KEY}</span>
-      - <span class="c-green">OPENCLAW_TOKEN=${OPENCLAW_TOKEN}</span>
-      - <span class="c-green">OPENCLAW_URL=http://host.docker.internal:${OPENCLAW_PORT:-18789}</span>
-      - <span class="c-green">DMZ_DVWA=${DMZ_DVWA}</span>
-      - <span class="c-green">DMZ_JUICESHOP=${DMZ_JUICESHOP}</span>
+      - <span class="c-green">ZAP_API_KEY=\${ZAP_API_KEY}</span>
+      - <span class="c-green">OPENCLAW_TOKEN=\${OPENCLAW_TOKEN}</span>
+      - <span class="c-green">OPENCLAW_URL=http://host.docker.internal:\${OPENCLAW_PORT:-18789}</span>
+      - <span class="c-green">DMZ_DVWA=\${DMZ_DVWA}</span>
+      - <span class="c-green">DMZ_JUICESHOP=\${DMZ_JUICESHOP}</span>
     <span class="c-yellow">volumes</span>:
       - <span class="c-green">n8n-data:/home/node/.n8n</span>
       - <span class="c-green">zap-reports:/zap-reports:ro</span>


### PR DESCRIPTION
## Summary
- Corrige SyntaxError en targets.js (y lab.js) por \\\ interpretado como interpolación JS.
- Escapa todas las referencias Docker Compose en los template strings.
- Añade textarea oculto para copiar compose en targets.

## Test plan
- [ ] Abrir la web y navegar a slide Targets y SecOps sin errores en consola


Made with [Cursor](https://cursor.com)